### PR TITLE
Add a docker based development environment

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,0 +1,3 @@
+FROM bretfisher/jekyll-serve
+
+RUN apk add git

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+
+services:
+  jekyll:
+    container_name: training-material
+    build:
+      context: .
+      dockerfile: ./.docker/Dockerfile
+    volumes:
+      - .:/site
+    ports:
+      - '8080:4000'


### PR DESCRIPTION
This is to easily locally serve the static Jekyll site (any branch)